### PR TITLE
Signing drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -270,6 +270,6 @@ services:
 
 ---
 kind: signature
-hmac: af5f0783363fae3f8876585fff87e08dd470ee9a81599f20e4c0e8d2d0836801
+hmac: b8315b01d7eb7d2e43bf41d5fdcaaecadc20a7b2ca2205af6e399b7901da4ebc
 
 ...


### PR DESCRIPTION
This signs the drone.yml for now to run drone CI