### PR TITLE
Fixed issue #51, change Joomla! logo glossy to flat colored

### DIFF
--- a/administrator/templates/khonsu/login.php
+++ b/administrator/templates/khonsu/login.php
@@ -35,7 +35,7 @@ $siteLogo  = $this->params->get('siteLogo')
 	: $this->baseurl . '/templates/' . $this->template . '/images/logo-joomla.svg';
 $loginLogo = $this->params->get('loginLogo')
 	? JUri::root() . $this->params->get('loginLogo')
-	: $this->baseurl . '/templates/' . $this->template . '/images/logo-glossy.svg';
+	: $this->baseurl . '/templates/' . $this->template . '/images/logo-colored.svg';
 $smallLogo = $this->params->get('smallLogo')
 	? JUri::root() . $this->params->get('smallLogo')
 	: $this->baseurl . '/templates/' . $this->template . '/images/logo.svg';

--- a/administrator/templates/khonsu/scss/blocks/_login.scss
+++ b/administrator/templates/khonsu/scss/blocks/_login.scss
@@ -91,13 +91,13 @@
     .login{
       flex: 0 0 100%;
       max-width: 100%;
-      padding: 3rem 4rem;
+      padding: 4rem;
       border-radius: 0 0 3px 3px;
       .main-brand>h3{
         font-size: 1.72rem;
         text-align: center;
         font-weight: normal;
-        margin-bottom: 4rem;
+        margin-bottom: 3rem;
         color: var(--primary-text-color);
         @include media-breakpoint-down(sm) {
           font-size: 1.2rem;
@@ -127,7 +127,7 @@
 
     img {
       height: 4.4rem;
-      padding: 15px;
+      margin-bottom: 15px;
     }
 
     #form-login {


### PR DESCRIPTION
Pull Request for Issue #51, glossy to flat Joomla! logo.

### Expected result
Flat colored logo.


### Actual result
Glossy colored logo.


### Documentation Changes Required

