### PR TITLE
Issue 56, searchtools toggle ordering direction button's accessibility.

### DIFF
--- a/layouts/joomla/searchtools/default/list.php
+++ b/layouts/joomla/searchtools/default/list.php
@@ -43,7 +43,6 @@ if (isset($list['list_fullordering'])) {
 							title="<?php echo !empty($orderDirn) && strtoupper($orderDirn) === 'ASC' ? Text::_('JGLOBAL_ORDER_DESCENDING_DIRN') : Text::_('JGLOBAL_ORDER_ASCENDING_DIRN'); ?>"
 							aria-label="<?php echo !empty($orderDirn) && strtoupper($orderDirn) === 'ASC' ? Text::_('JGLOBAL_ORDER_DESCENDING_DIRN') : Text::_('JGLOBAL_ORDER_ASCENDING_DIRN'); ?>"
 						>
-							<span class="sr-only"><?php echo !empty($orderDirn) && strtoupper($orderDirn) === 'ASC' ? Text::_('JGLOBAL_ORDER_DESCENDING_DIRN') : Text::_('JGLOBAL_ORDER_ASCENDING_DIRN'); ?></span>
 							<span class="duotone icon-lg <?php echo !empty($orderDirn) && strtoupper($orderDirn) === 'ASC' ? 'icon-descending' : 'icon-ascending'; ?>"></span>
 						</button>
 					<?php endif; ?>

--- a/layouts/joomla/searchtools/default/list.php
+++ b/layouts/joomla/searchtools/default/list.php
@@ -38,7 +38,14 @@ if (isset($list['list_fullordering'])) {
 						</div>
 					</div>
 					<?php if($fieldName === 'list_fullordering') : ?>
-						<button type="button" class="btn btn-link js-stools-order-toggler hasTooltip" title="<?php echo !empty($orderDirn) && strtoupper($orderDirn) === 'ASC' ? Text::_('JGLOBAL_ORDER_DESCENDING_DIRN') : Text::_('JGLOBAL_ORDER_ASCENDING_DIRN'); ?>"><i class="duotone icon-lg <?php echo !empty($orderDirn) && strtoupper($orderDirn) === 'ASC' ? 'icon-descending' : 'icon-ascending'; ?>"></i></button>
+						<button type="button" 
+							class="btn btn-link js-stools-order-toggler hasTooltip" 
+							title="<?php echo !empty($orderDirn) && strtoupper($orderDirn) === 'ASC' ? Text::_('JGLOBAL_ORDER_DESCENDING_DIRN') : Text::_('JGLOBAL_ORDER_ASCENDING_DIRN'); ?>"
+							aria-label="<?php echo !empty($orderDirn) && strtoupper($orderDirn) === 'ASC' ? Text::_('JGLOBAL_ORDER_DESCENDING_DIRN') : Text::_('JGLOBAL_ORDER_ASCENDING_DIRN'); ?>"
+						>
+							<span class="sr-only"><?php echo !empty($orderDirn) && strtoupper($orderDirn) === 'ASC' ? Text::_('JGLOBAL_ORDER_DESCENDING_DIRN') : Text::_('JGLOBAL_ORDER_ASCENDING_DIRN'); ?></span>
+							<span class="duotone icon-lg <?php echo !empty($orderDirn) && strtoupper($orderDirn) === 'ASC' ? 'icon-descending' : 'icon-ascending'; ?>"></span>
+						</button>
 					<?php endif; ?>
 				</div>
 			<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #56 .

### Summary of Changes
This PR fixes the following issue by placing an `aria-label` attribute on the button.

