### PR TITLE
Fixed dashboard card collapse/expand issue #85

### DIFF
--- a/build/media_source/com_cpanel/js/admin-cpanel-default.es6.js
+++ b/build/media_source/com_cpanel/js/admin-cpanel-default.es6.js
@@ -49,6 +49,53 @@
     });
   };
 
+  /**
+   * Expand/collapse card body
+   *
+   * @param   {HTMLElement}   card  Card element
+   *
+   * @since   4.0.0
+   */
+  const toggleCard = (card) => {
+    card.addEventListener('click', (event) => {
+      event.preventDefault();
+      const targetBody = document.getElementById(card.getAttribute('data-target'));
+      const { currentTarget: el } = event;
+
+      if (el) {
+        // Toggle aria-expanded attribute
+        if (el.hasAttribute('aria-expanded')) {
+          if (el.getAttribute('aria-expanded') === 'true') {
+            el.setAttribute('aria-expanded', 'false');
+          } else {
+            el.setAttribute('aria-expanded', 'true');
+          }
+        }
+
+        // Toggle collapse icon
+        const icon = el.querySelector('span.toggle-icon');
+        if (icon) {
+          if (icon.classList.contains('icon-chevron-down')) {
+            icon.classList.remove('icon-chevron-down');
+            icon.classList.add('icon-chevron-up');
+          } else {
+            icon.classList.remove('icon-chevron-up');
+            icon.classList.add('icon-chevron-down');
+          }
+        }
+      }
+
+      if (targetBody) {
+        if (targetBody.classList.contains('collapse-in')) {
+          targetBody.classList.remove('collapse-in');
+        } else {
+          targetBody.classList.add('collapse-in');
+        }
+      }
+    });
+  };
+
+
   const onBoot = () => {
     // Find matchesFn with vendor prefix
     ['matches', 'msMatchesSelector'].some((fn) => {
@@ -58,6 +105,14 @@
       }
       return false;
     });
+
+    // Get the dashboard's card elements
+    const cpanelCards = document.querySelectorAll('.joomla-collapse-card-body');
+    if (cpanelCards) {
+      cpanelCards.forEach((card) => {
+        toggleCard(card);
+      });
+    }
 
     const cpanelModules = document.getElementById('cpanel-modules');
     if (cpanelModules) {

--- a/build/media_source/mod_quickicon/js/quickicon.es6.js
+++ b/build/media_source/mod_quickicon/js/quickicon.es6.js
@@ -13,22 +13,8 @@
    * The class pulse gets 'warning', 'success' or 'error', depending on the retrieved data.
    */
   document.addEventListener('DOMContentLoaded', () => {
-    document.querySelectorAll('.joomla-collapse-card-body').forEach((card) => {
-      card.addEventListener('click', (event) => {
-        event.preventDefault();
-        const targetBody = document.getElementById(card.getAttribute('data-target'));
-        if (targetBody) {
-          if (targetBody.classList.contains('collapse-in')) {
-            targetBody.classList.remove('collapse-in');
-          } else {
-            targetBody.classList.add('collapse-in');
-          }
-        }
-      });
-    });
     document.querySelectorAll('.j-quickicon').forEach((quickicon) => {
       const pulse = quickicon.querySelector('.pulse');
-      // quickicon.classList.add('j-quickicon-skeleton');
       const counterAnimate = quickicon.querySelector('.j-counter-animation');
       if (quickicon.dataset.url) {
         Joomla.request({


### PR DESCRIPTION
Pull Request for Issue #85.

### Summary of Changes
The problem is the toggle card button not performing as it should be. The script was dependent on the `mod_quickicon` administrator module. That's why there needs to add the module at the dashboard. 
Now the dependency is removed from the `mod_quickicon` module. Besides this PR added proper `aria-expanded` attribute value change.

### Expected Result
Click on the button on the card header collapse/expand the card body.

### Actual Result
Perform nothing.

### Testing Instruction
Login to administrator --> Go to dashboard --> click up arrow --> card body collapsed --> click again --> card body expanded.
