### PR TITLE
Fixed issue #83, Inconsistent status field in module form.

### DIFF
--- a/administrator/components/com_modules/forms/module.xml
+++ b/administrator/components/com_modules/forms/module.xml
@@ -47,7 +47,7 @@
 
 		<field
 			name="published"
-			type="radio"
+			type="list"
 			label="JSTATUS"
 			class="custom-select-color-state module-publish"
 			default="1"


### PR DESCRIPTION
Pull Request for Issue #83.

### Summary of Changes
The input type changes from 'radio' to 'list' at `/administrator/components/com_modules/forms/module.xml`.

### Expected Result
The status should be the `select option` field.

### Actual Result
It shows radio buttons.
