### PR TITLE
Fixed issue #81, Alignment of table row and body

### DIFF
--- a/administrator/templates/khonsu/scss/blocks/_j-table.scss
+++ b/administrator/templates/khonsu/scss/blocks/_j-table.scss
@@ -225,7 +225,7 @@ table {
             }
             td {
                 border: 0;
-                padding: 15px 0;
+                padding: 15px 10px;
                 line-height: 1;
                 .btn {
                     line-height: 1;


### PR DESCRIPTION
Pull Request for Issue #81.

### Summary of Changes
Changes of the tbody > td padding solves the problem.

### Expected Result
<img width="1146" alt="expected" src="https://user-images.githubusercontent.com/5783354/69420748-81d1b780-0d49-11ea-9b4a-d438abe28473.png">


### Actual Result
<img width="1146" alt="actual" src="https://user-images.githubusercontent.com/892204/69365180-b9e7e480-0cce-11ea-9ea6-44c957d1da08.png">

### Test Instructions
At sidebar menu `System > Information > System Information`. Check tabs.
