### PR TITLE
Fixed issue #133, templates file upload folder selection issue.

### DIFF
--- a/administrator/components/com_templates/tmpl/template/default_folders.php
+++ b/administrator/components/com_templates/tmpl/template/default_folders.php
@@ -15,7 +15,7 @@ ksort($this->files, SORT_STRING);
 	<?php foreach($this->files as $key => $value) : ?>
 		<?php if (is_array($value)) : ?>
 			<li class="folder-select has-subtree">
-				<a class="folder-url" data-id="<?php echo base64_encode($key); ?>" href="">
+				<a class="folder-url" data-id="<?php echo base64_encode($key); ?>" href="javascript:void(0);">
 					<span class="icon-folder-2" aria-hidden="true"></span>
 					<?php $explodeArray = explode('/', $key); echo $this->escape(end($explodeArray)); ?>
 				</a>

--- a/administrator/components/com_templates/tmpl/template/default_tree.php
+++ b/administrator/components/com_templates/tmpl/template/default_tree.php
@@ -50,7 +50,7 @@ ksort($this->files, SORT_NATURAL);
 
 			?>
 			<li class="<?php echo $class; ?> has-subtree">
-				<a class="folder-url" href="">
+				<a class="folder-url" href="javascript:void(0);">
 					<span class="icon-folder-2" aria-hidden="true"></span>
 					<span class="folder-name">&nbsp;<?php $explodeArray = explode('/', $key); echo $this->escape(end($explodeArray)); ?></span>
 				</a>

--- a/administrator/templates/khonsu/scss/blocks/_treeselect.scss
+++ b/administrator/templates/khonsu/scss/blocks/_treeselect.scss
@@ -124,6 +124,7 @@
     }
   }
   .has-subtree {
+
     .directory-tree {
       margin-left: ($treeselect-indent - 10px);
       margin-top: -5px;

--- a/administrator/templates/khonsu/scss/blocks/_treeselect.scss
+++ b/administrator/templates/khonsu/scss/blocks/_treeselect.scss
@@ -87,6 +87,13 @@
     position: relative;
     display: block;
     list-style: none;
+    line-height: 25px;
+
+    a {
+      &.folder-url {
+        padding-left: 5px;
+      }
+    }
 
    &::before {
       position: absolute;
@@ -118,7 +125,7 @@
   }
   .has-subtree {
     .directory-tree {
-      margin-left: ($treeselect-indent - 15px);
+      margin-left: ($treeselect-indent - 10px);
       margin-top: -5px;
       li {
         &:first-child {

--- a/build/media_source/com_templates/js/admin-templates-default.es6.js
+++ b/build/media_source/com_templates/js/admin-templates-default.es6.js
@@ -9,8 +9,7 @@
     const folders = [].slice.call(document.querySelectorAll('.folder-url, .component-folder-url, .plugin-folder-url, .layout-folder-url'));
     const innerLists = [].slice.call(document.querySelectorAll('.folder ul, .component-folder ul, .plugin-folder ul, .layout-folder ul'));
     const openLists = [].slice.call(document.querySelectorAll('.show > ul'));
-    const fileModalFolders = [].slice.call(document.querySelectorAll('#fileModal .folder-url'));
-    const folderModalFolders = [].slice.call(document.querySelectorAll('#folderModal .folder-url'));
+
     // Hide all the folders when the page loads
     innerLists.forEach((innerList) => {
       innerList.style.display = 'none';
@@ -37,38 +36,65 @@
     });
 
     // File modal tree selector
-    fileModalFolders.forEach((fileModalFolder) => {
-      fileModalFolder.addEventListener('click', (event) => {
-        event.preventDefault();
+    document.getElementById('fileModal').addEventListener('joomla.modal.show', () => {
+      const fileModalFolders = [].slice.call(document.querySelectorAll('#fileModal .folder-url'));
 
-        fileModalFolders.forEach((fileModalFold) => {
-          fileModalFold.classList.remove('selected');
-        });
+      fileModalFolders.forEach((fileModalFolder) => {
+        fileModalFolder.addEventListener('click', (event) => {
+          event.preventDefault();
 
-        event.target.classList.add('selected');
+          fileModalFolders.forEach((fileModalFold) => {
+            fileModalFold.classList.remove('selected');
+          });
 
-        const listElsAddressToAdd = [].slice.call(document.querySelectorAll('#fileModal input.address'));
+          event.target.classList.add('selected');
 
-        listElsAddressToAdd.forEach((element) => {
-          element.value = event.target.getAttribute('data-id');
+          const listElsAddressToAdd = [].slice.call(document.querySelectorAll('#fileModal input.address'));
+
+          listElsAddressToAdd.forEach((element) => {
+            element.value = event.target.getAttribute('data-id');
+          });
+
+          // Expand/collapse folder
+          const children = fileModalFolder.nextElementSibling;
+          if (typeof children.style.display !== 'undefined') {
+            if (children.style.display === '' || children.style.display === 'block') {
+              children.style.display = 'none';
+            } else {
+              children.style.display = 'block';
+            }
+          }
         });
       });
     });
 
     // Folder modal tree selector
-    folderModalFolders.forEach((folderModalFolder) => {
-      folderModalFolder.addEventListener('click', (event) => {
-        event.preventDefault();
+    document.getElementById('folderModal').addEventListener('joomla.modal.show', () => {
+      const folderModalFolders = [].slice.call(document.querySelectorAll('#folderModal .folder-url'));
+      folderModalFolders.forEach((folderModalFolder) => {
+        folderModalFolder.addEventListener('click', (event) => {
+          event.preventDefault();
 
-        folderModalFolders.forEach((folderModalFldr) => {
-          folderModalFldr.classList.remove('selected');
-        });
+          folderModalFolders.forEach((folderModalFldr) => {
+            folderModalFldr.classList.remove('selected');
+          });
 
-        event.target.classList.add('selected');
-        const listElsAddressToAdd = [].slice.call(document.querySelectorAll('#folderModal input.address'));
+          event.target.classList.add('selected');
+          const listElsAddressToAdd = [].slice.call(document.querySelectorAll('#folderModal input.address'));
 
-        listElsAddressToAdd.forEach((element) => {
-          element.value = event.target.getAttribute('data-id');
+          listElsAddressToAdd.forEach((element) => {
+            element.value = event.target.getAttribute('data-id');
+          });
+
+          // Expand/collapse folder
+          const children = folderModalFolder.nextElementSibling;
+          if (typeof children.style.display !== 'undefined') {
+            if (children.style.display === '' || children.style.display === 'block') {
+              children.style.display = 'none';
+            } else {
+              children.style.display = 'block';
+            }
+          }
         });
       });
     });


### PR DESCRIPTION
Pull Request for Issue #133 .

### Summary of Changes
This pull request fixes template file upload modal's folder selection issue. And also improve `scss`.


### Testing Instructions
Go to `Extensions > Templates > On Cassiopeia template click Edit Files > Click New File


### Expected result
At the left side folder tree by clicking on a folder should select the folder and toggle its descendants.
<img width="1439" alt="Screenshot 2019-12-02 at 12 32 06 PM" src="https://user-images.githubusercontent.com/5783354/69936073-db33a680-1500-11ea-8038-ea212932233f.png">


### Actual result
It reloaded the page by clicking on the folders.


### Documentation Changes Required

