### PR TITLE
Fixed issue #131, Template style filters.

### DIFF
--- a/administrator/components/com_templates/View/Styles/HtmlView.php
+++ b/administrator/components/com_templates/View/Styles/HtmlView.php
@@ -89,6 +89,13 @@ class HtmlView extends BaseHtmlView
 		$this->activeFilters = $this->get('ActiveFilters');
 		$this->preview       = ComponentHelper::getParams('com_templates')->get('template_positions_display');
 
+		// Remove the menu item filter for administrator styles.
+		if ((int) $this->state->get('client_id') !== 0)
+		{
+			unset($this->activeFilters['menuitem']);
+			$this->filterForm->removeField('menuitem', 'filter');
+		}
+
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{


### PR DESCRIPTION
Pull Request for Issue #131 .

### Summary of Changes
Remove the filter by `menuitem` form field if the client is the administrator.


### Testing Instructions
Go to `Extensions > Templates > Click Administrator button > Click Show Filter button`


### Expected result
<img width="1440" alt="Screenshot 2019-12-03 at 11 49 57 AM" src="https://user-images.githubusercontent.com/5783354/70024064-7ab96d80-15c3-11ea-853a-81440ff848ba.png">



### Actual result
<img width="1440" alt="Actual" src="https://user-images.githubusercontent.com/1296369/69919489-27d1a000-1475-11ea-8a53-3894de08d6ff.png">


### Documentation Changes Required

