### PR TITLE
Fix issue #150: New item menu - Can't select the 'menu item type' at …

### DIFF
--- a/build/media_source/com_menus/js/admin-item-modal.es6.js
+++ b/build/media_source/com_menus/js/admin-item-modal.es6.js
@@ -9,7 +9,7 @@ Joomla = window.Joomla || {};
 
   Joomla.setMenuType = (type, tmpl) => {
     if (tmpl !== '') {
-      window.parent.Joomla.submitbutton('item.setType', type);
+      window.Joomla.submitbutton('item.setType', type);
       // window.parent.Joomla.Modal.getCurrent().close();
     } else {
       window.location = `index.php?option=com_menus&view=item&task=item.setType&layout=edit&type=${type}`;


### PR DESCRIPTION
Pull Request for Issue #150  .

### Summary of Changes
Edit build/media-source/admin-item-modal.es6.js file:
Replace this line: window.parent.Joomla.submitbutton('item.setType', type);
by
window.Joomla.submitbutton('item.setType', type);

### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

