### PR TITLE
Fixed issue #156, workflow edit view title field missing issue.

### DIFF
--- a/administrator/components/com_workflow/tmpl/workflow/edit.php
+++ b/administrator/components/com_workflow/tmpl/workflow/edit.php
@@ -31,7 +31,7 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 <form action="<?php echo Route::_('index.php?option=com_workflow&extension=' . $input->getCmd('extension') . '&layout=' . $layout . $tmpl . '&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="workflow-form" class="form-validate">
 
 	<div class="form-no-margin">
-		<?php echo LayoutHelper::render('joomla.edit.title', $this); ?>
+		<?php echo LayoutHelper::render('joomla.edit.title_alias', $this); ?>
 	</div>
 			
 


### PR DESCRIPTION
Pull Request for Issue #156 .

### Summary of Changes
Add the correct layout for rendering the title field.


### Testing Instructions
Go to Contents > Workflows > Click New


### Expected result
<img width="1366" alt="Screenshot 2019-12-13 at 12 28 41 PM" src="https://user-images.githubusercontent.com/5783354/70774572-d692ac00-1da4-11ea-9db2-b0035bbb1667.png">


### Actual result
![70695717-e2bf3080-1cf4-11ea-97b7-f8cc18d954e2](https://user-images.githubusercontent.com/5783354/70774715-1194df80-1da5-11ea-9e3b-6d3af82bb939.png)

